### PR TITLE
ElevenLabs-DotNet 1.1.1

### DIFF
--- a/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
+++ b/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
@@ -15,7 +15,7 @@
         <PackageTags>ElevenLabs, AI, ML, API, api-proxy, proxy, gateway</PackageTags>
         <Title>ElevenLabs API Proxy</Title>
         <PackageId>ElevenLabs-DotNet-Proxy</PackageId>
-        <Version>1.0.0</Version>
+        <Version>1.0.1</Version>
         <RootNamespace>ElevenLabs.Proxy</RootNamespace>
         <PackageReleaseNotes>Initial Release!</PackageReleaseNotes>
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
+++ b/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
@@ -12,7 +12,7 @@
     <Authors>Stephen Hodgson</Authors>
     <Title>ElevenLabs-DotNet</Title>
     <Company>RageAgainstThePixel</Company>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Copyright>2023</Copyright>
     <PackageTags>ElevenLabs, AI, ML, Voice, TTS</PackageTags>
     <PackageReleaseNotes>Release 1.1.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Discord](https://img.shields.io/discord/855294214065487932.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/xQgMW9ufN4)
 [![NuGet version (ElevenLabs-DotNet)](https://img.shields.io/nuget/v/ElevenLabs-DotNet.svg)](https://www.nuget.org/packages/ElevenLabs-DotNet/)
+[![NuGet version (ElevenLabs-DotNet-Proxy)](https://img.shields.io/nuget/v/ElevenLabs-DotNet-Proxy.svg?label=ElevenLabs-DotNet-Proxy&logo=nuget)](https://www.nuget.org/packages/ElevenLabs-DotNet-Proxy/)
 [![Nuget Publish](https://github.com/RageAgainstThePixel/ElevenLabs-DotNet/actions/workflows/Publish-Nuget.yml/badge.svg)](https://github.com/RageAgainstThePixel/ElevenLabs-DotNet/actions/workflows/Publish-Nuget.yml)
 
 A non-official [Eleven Labs](https://elevenlabs.io/) voice synthesis RESTful client.


### PR DESCRIPTION
- fixed docs
- fixed deps for proxy
- bump proxy to 1.0.1