### PR TITLE
Added Voice.HighQualityBaseModelIds property

### DIFF
--- a/ElevenLabs-DotNet/Voices/Voice.cs
+++ b/ElevenLabs-DotNet/Voices/Voice.cs
@@ -42,6 +42,11 @@ namespace ElevenLabs.Voices
         public IReadOnlyList<string> AvailableForTiers { get; private set; }
 
         [JsonInclude]
+        [JsonPropertyName("high_quality_base_model_ids")]
+        public IReadOnlyList<string> HighQualityBaseModelIds { get; private set; }
+
+
+        [JsonInclude]
         [JsonPropertyName("settings")]
         public VoiceSettings Settings { get; internal set; }
 
@@ -99,6 +104,7 @@ namespace ElevenLabs.Voices
                    Equals(Labels, other.Labels) &&
                    PreviewUrl == other.PreviewUrl &&
                    Equals(AvailableForTiers, other.AvailableForTiers) &&
+                   Equals(HighQualityBaseModelIds, other.HighQualityBaseModelIds) &&
                    Equals(Settings, other.Settings);
         }
 


### PR DESCRIPTION
Adds `Voice.HighQualityBaseModelIds` property to allow deserialization of that field from ElevenLabs API.

This property allows the developer to determine if the MultiLingual model should be used to render the voice instead of the monolingual.