### PR TITLE
Allow to use the API without file system

### DIFF
--- a/ElevenLabs-DotNet/TextToSpeech/TextToSpeechEndpoint.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TextToSpeechEndpoint.cs
@@ -84,7 +84,7 @@ namespace ElevenLabs.TextToSpeech
         /// <param name="deleteCachedFile">Optional, deletes the cached file for this text string. Default is false.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>Downloaded clip path.</returns>
-        public async Task<byte[]> TextToSpeechAsyncRaw(string text, Voice voice, VoiceSettings voiceSettings = null, Model model = null, string saveDirectory = null, bool deleteCachedFile = false, CancellationToken cancellationToken = default)
+        public async Task<byte[]> TextToSpeechRawAsync(string text, Voice voice, VoiceSettings voiceSettings = null, Model model = null, string saveDirectory = null, bool deleteCachedFile = false, CancellationToken cancellationToken = default)
         {
             var responseStream = await TextToSpeechStreamAsync(text, voice, voiceSettings, model, saveDirectory, deleteCachedFile, cancellationToken);
             using var memoryStream = new MemoryStream();

--- a/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
@@ -135,15 +135,6 @@ namespace ElevenLabs.Voices
         /// Add a new voice to your collection of voices in VoiceLab.
         /// </summary>
         /// <param name="name">Name of the voice you want to add.</param>
-        /// <param name="labels">Optional, labels for the new voice.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        public Task<Voice> AddVoiceAsync(string name, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
-            => AddVoiceAsync(name, Enumerable.Empty<string>(), labels, cancellationToken);
-
-        /// <summary>
-        /// Add a new voice to your collection of voices in VoiceLab.
-        /// </summary>
-        /// <param name="name">Name of the voice you want to add.</param>
         /// <param name="samplePaths">Collection of file paths to use as samples for the new voice.</param>
         /// <param name="labels">Optional, labels for the new voice.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
@@ -200,7 +191,7 @@ namespace ElevenLabs.Voices
         /// <param name="samples">Collection of samples for the new voice.</param>
         /// <param name="labels">Optional, labels for the new voice.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        public async Task<Voice> AddVoiceAsync(string name, IEnumerable<byte[]> samples = null, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+        public async Task<Voice> AddVoiceAsync(string name, IEnumerable<byte[]> samples, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
         {
             var form = new MultipartFormDataContent();
 
@@ -234,16 +225,6 @@ namespace ElevenLabs.Voices
             var voice = await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken);
             return voice;
         }
-
-        /// <summary>
-        /// Edit a voice created by you.
-        /// </summary>
-        /// <param name="voice">The <see cref="Voice"/> to edit.</param>
-        /// <param name="labels">The labels to set on the <see cref="Voice"/> description.</param>
-        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
-        /// <returns>True, if voice was successfully edited.</returns>
-        public Task<bool> EditVoiceAsync(Voice voice, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
-            => EditVoiceAsync(voice, Enumerable.Empty<string>(), labels, cancellationToken);
 
         /// <summary>
         /// Edit a voice created by you.
@@ -305,7 +286,7 @@ namespace ElevenLabs.Voices
         /// <param name="labels">The labels to set on the <see cref="Voice"/> description.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns>True, if voice was successfully edited.</returns>
-        public async Task<bool> EditVoiceAsync(Voice voice, IEnumerable<byte[]> samples = null, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+        public async Task<bool> EditVoiceAsync(Voice voice, IEnumerable<byte[]> samples, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
         {
             var form = new MultipartFormDataContent();
 

--- a/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
@@ -135,6 +135,15 @@ namespace ElevenLabs.Voices
         /// Add a new voice to your collection of voices in VoiceLab.
         /// </summary>
         /// <param name="name">Name of the voice you want to add.</param>
+        /// <param name="labels">Optional, labels for the new voice.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        public Task<Voice> AddVoiceAsync(string name, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+            => AddVoiceAsync(name, Enumerable.Empty<string>(), labels, cancellationToken);
+
+        /// <summary>
+        /// Add a new voice to your collection of voices in VoiceLab.
+        /// </summary>
+        /// <param name="name">Name of the voice you want to add.</param>
         /// <param name="samplePaths">Collection of file paths to use as samples for the new voice.</param>
         /// <param name="labels">Optional, labels for the new voice.</param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
@@ -225,6 +234,16 @@ namespace ElevenLabs.Voices
             var voice = await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken);
             return voice;
         }
+
+        /// <summary>
+        /// Edit a voice created by you.
+        /// </summary>
+        /// <param name="voice">The <see cref="Voice"/> to edit.</param>
+        /// <param name="labels">The labels to set on the <see cref="Voice"/> description.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>True, if voice was successfully edited.</returns>
+        public Task<bool> EditVoiceAsync(Voice voice, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+            => EditVoiceAsync(voice, Enumerable.Empty<string>(), labels, cancellationToken);
 
         /// <summary>
         /// Edit a voice created by you.

--- a/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
@@ -185,6 +185,48 @@ namespace ElevenLabs.Voices
         }
 
         /// <summary>
+        /// Add a new voice to your collection of voices in VoiceLab.
+        /// </summary>
+        /// <param name="name">Name of the voice you want to add.</param>
+        /// <param name="samples">Collection of samples for the new voice.</param>
+        /// <param name="labels">Optional, labels for the new voice.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        public async Task<Voice> AddVoiceAsync(string name, IEnumerable<byte[]> samples = null, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+        {
+            var form = new MultipartFormDataContent();
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            form.Add(new StringContent(name), "name");
+
+            if (samples != null)
+            {
+                foreach (var sample in samples)
+                {
+                    if (sample.Length == 0)
+                    {
+                        throw new ArgumentException("Empty samples are not supported.");
+                    }
+                    form.Add(new ByteArrayContent(sample), "files");
+                }
+            }
+
+            if (labels != null)
+            {
+                form.Add(new StringContent(JsonSerializer.Serialize(labels)), "labels");
+            }
+
+            var response = await Api.Client.PostAsync(GetUrl("/add"), form, cancellationToken);
+            var responseAsString = await response.ReadAsStringAsync();
+            var voiceResponse = JsonSerializer.Deserialize<VoiceResponse>(responseAsString, Api.JsonSerializationOptions);
+            var voice = await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken);
+            return voice;
+        }
+
+        /// <summary>
         /// Edit a voice created by you.
         /// </summary>
         /// <param name="voice">The <see cref="Voice"/> to edit.</param>
@@ -223,6 +265,47 @@ namespace ElevenLabs.Voices
                         await fileStream.DisposeAsync();
                         await stream.DisposeAsync();
                     }
+                }
+            }
+
+            if (labels != null)
+            {
+                form.Add(new StringContent(JsonSerializer.Serialize(labels)), "labels");
+            }
+
+            var response = await Api.Client.PostAsync(GetUrl($"/{voice.Id}/edit"), form, cancellationToken);
+            await response.CheckResponseAsync(cancellationToken);
+            return response.IsSuccessStatusCode;
+        }
+
+        /// <summary>
+        /// Edit a voice created by you.
+        /// </summary>
+        /// <param name="voice">The <see cref="Voice"/> to edit.</param>
+        /// <param name="samples">The samples to upload.</param>
+        /// <param name="labels">The labels to set on the <see cref="Voice"/> description.</param>
+        /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+        /// <returns>True, if voice was successfully edited.</returns>
+        public async Task<bool> EditVoiceAsync(Voice voice, IEnumerable<byte[]> samples = null, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+        {
+            var form = new MultipartFormDataContent();
+
+            if (voice == null)
+            {
+                throw new ArgumentNullException(nameof(voice));
+            }
+
+            form.Add(new StringContent(voice.Name), "name");
+
+            if (samples != null)
+            {
+                foreach (var sample in samples)
+                {
+                    if (sample.Length == 0)
+                    {
+                        throw new ArgumentException("Empty samples are not supported.");
+                    }
+                    form.Add(new ByteArrayContent(sample), "files");
                 }
             }
 


### PR DESCRIPTION
This PR is to allow the library without reading / storing audio files with samples from the file system.
Instead, `byte[]` is used to send / receive data.