### PR TITLE
ElevenLabs-DotNet 2.2.0

### DIFF
--- a/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
+++ b/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
@@ -1,48 +1,48 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>disable</ImplicitUsings>
-        <Nullable>disable</Nullable>
-        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <SignAssembly>false</SignAssembly>
-        <Authors>Stephen Hodgson</Authors>
-        <Product>ElevenLabs-DotNet-Proxy</Product>
-        <Description>A simple Proxy API gateway for ElevenLabs-DotNet to make authenticated requests from a front end application without exposing your API keys.</Description>
-        <Copyright>2023</Copyright>
-        <PackageProjectUrl>https://github.com/RageAgainstThePixel/ElevenLabs-DotNet</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/RageAgainstThePixel/ElevenLabs-DotNet</RepositoryUrl>
-        <PackageTags>ElevenLabs, AI, ML, API, api-proxy, proxy, gateway</PackageTags>
-        <Title>ElevenLabs API Proxy</Title>
-        <PackageId>ElevenLabs-DotNet-Proxy</PackageId>
-        <Version>1.0.1</Version>
-        <RootNamespace>ElevenLabs.Proxy</RootNamespace>
-        <PackageReleaseNotes>Initial Release!</PackageReleaseNotes>
-        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <PackageReadmeFile>Readme.md</PackageReadmeFile>
-        <IncludeSymbols>True</IncludeSymbols>
-        <PackageIcon>ElevenLabsIcon.png</PackageIcon>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    </PropertyGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\ElevenLabs-DotNet\ElevenLabs-DotNet.csproj" />
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Include="..\ElevenLabs-DotNet\Assets\ElevenLabsIcon.png">
-        <Pack>True</Pack>
-        <PackagePath>\</PackagePath>
-      </None>
-      <None Include="..\LICENSE">
-        <Pack>True</Pack>
-        <PackagePath>\</PackagePath>
-      </None>
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="Readme.md">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <SignAssembly>false</SignAssembly>
+    <Authors>Stephen Hodgson</Authors>
+    <Product>ElevenLabs-DotNet-Proxy</Product>
+    <Description>A simple Proxy API gateway for ElevenLabs-DotNet to make authenticated requests from a front end application without exposing your API keys.</Description>
+    <Copyright>2024</Copyright>
+    <PackageProjectUrl>https://github.com/RageAgainstThePixel/ElevenLabs-DotNet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/RageAgainstThePixel/ElevenLabs-DotNet</RepositoryUrl>
+    <PackageTags>ElevenLabs, AI, ML, API, api-proxy, proxy, gateway</PackageTags>
+    <Title>ElevenLabs API Proxy</Title>
+    <PackageId>ElevenLabs-DotNet-Proxy</PackageId>
+    <Version>1.2.0</Version>
+    <RootNamespace>ElevenLabs.Proxy</RootNamespace>
+    <PackageReleaseNotes>Initial Release!</PackageReleaseNotes>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageReadmeFile>Readme.md</PackageReadmeFile>
+    <IncludeSymbols>True</IncludeSymbols>
+    <PackageIcon>ElevenLabsIcon.png</PackageIcon>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ElevenLabs-DotNet\ElevenLabs-DotNet.csproj" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ElevenLabs-DotNet\Assets\ElevenLabsIcon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Readme.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 </Project>

--- a/ElevenLabs-DotNet-Proxy/Proxy/AbstractAuthenticationFilter.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/AbstractAuthenticationFilter.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace ElevenLabs.Proxy
@@ -9,5 +10,8 @@ namespace ElevenLabs.Proxy
     {
         /// <inheritdoc />
         public abstract void ValidateAuthentication(IHeaderDictionary request);
+
+        /// <inheritdoc />
+        public abstract Task ValidateAuthenticationAsync(IHeaderDictionary request);
     }
 }

--- a/ElevenLabs-DotNet-Proxy/Proxy/IAuthenticationFilter.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/IAuthenticationFilter.cs
@@ -1,7 +1,8 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Security.Authentication;
 using Microsoft.AspNetCore.Http;
+using System.Security.Authentication;
+using System.Threading.Tasks;
 
 namespace ElevenLabs.Proxy
 {
@@ -17,5 +18,13 @@ namespace ElevenLabs.Proxy
         /// <param name="request"></param>
         /// <exception cref="AuthenticationException"></exception>
         void ValidateAuthentication(IHeaderDictionary request);
+
+        /// <summary>
+        /// Checks the headers for your user issued token.
+        /// If it's not valid, then throw <see cref="AuthenticationException"/>.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <exception cref="AuthenticationException"></exception>
+        Task ValidateAuthenticationAsync(IHeaderDictionary request);
     }
 }

--- a/ElevenLabs-DotNet-Tests-Proxy/Program.cs
+++ b/ElevenLabs-DotNet-Tests-Proxy/Program.cs
@@ -2,8 +2,8 @@
 
 using ElevenLabs.Proxy;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Hosting;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 
 namespace ElevenLabs.Tests.Proxy
 {
@@ -27,14 +27,25 @@ namespace ElevenLabs.Tests.Proxy
                     throw new AuthenticationException("User is not authorized");
                 }
             }
+
+            public override async Task ValidateAuthenticationAsync(IHeaderDictionary request)
+            {
+                await Task.CompletedTask; // remote resource call
+
+                // You will need to implement your own class to properly test
+                // custom issued tokens you've setup for your end users.
+                if (!request["xi-api-key"].ToString().Contains(TestUserToken))
+                {
+                    throw new AuthenticationException("User is not authorized");
+                }
+            }
         }
 
         public static void Main(string[] args)
         {
             var auth = ElevenLabsAuthentication.LoadFromEnv();
             var client = new ElevenLabsClient(auth);
-            var proxy = ElevenLabsProxyStartup.CreateDefaultHost<AuthenticationFilter>(args, client);
-            proxy.Run();
+            ElevenLabsProxyStartup.CreateWebApplication<AuthenticationFilter>(args, client).Run();
         }
     }
 }

--- a/ElevenLabs-DotNet-Tests/Test_Fixture_02_VoicesEndpoint.cs
+++ b/ElevenLabs-DotNet-Tests/Test_Fixture_02_VoicesEndpoint.cs
@@ -86,7 +86,43 @@ namespace ElevenLabs.Tests
         }
 
         [Test]
-        public async Task Test_06_EditVoice()
+        public async Task Test_06_AddVoiceFromByteArray()
+        {
+            Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
+            var testLabels = new Dictionary<string, string>
+            {
+                { "accent", "american" }
+            };
+            var clipPath = Path.GetFullPath("../../../Assets/test_sample_01.ogg");
+            byte[] clipData = await File.ReadAllBytesAsync(clipPath);
+            var result = await ElevenLabsClient.VoicesEndpoint.AddVoiceAsync("Test Voice", new[] { clipData }, testLabels);
+            Assert.NotNull(result);
+            Console.WriteLine($"{result.Name}");
+            Assert.IsNotEmpty(result.Samples);
+        }
+
+
+        [Test]
+        public async Task Test_07_AddVoiceFromStream()
+        {
+            Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
+            var testLabels = new Dictionary<string, string>
+            {
+                { "accent", "american" }
+            };
+            var clipPath = Path.GetFullPath("../../../Assets/test_sample_01.ogg");
+
+            using (FileStream fs = File.OpenRead(clipPath))
+            {
+                var result = await ElevenLabsClient.VoicesEndpoint.AddVoiceAsync("Test Voice", new[] { fs }, testLabels);
+                Assert.NotNull(result);
+                Console.WriteLine($"{result.Name}");
+                Assert.IsNotEmpty(result.Samples);
+            }
+        }
+
+        [Test]
+        public async Task Test_08_EditVoice()
         {
             Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
             var results = await ElevenLabsClient.VoicesEndpoint.GetAllVoicesAsync();
@@ -106,7 +142,7 @@ namespace ElevenLabs.Tests
         }
 
         [Test]
-        public async Task Test_07_GetVoiceSample()
+        public async Task Test_09_GetVoiceSample()
         {
             Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
             var results = await ElevenLabsClient.VoicesEndpoint.GetAllVoicesAsync();
@@ -124,7 +160,7 @@ namespace ElevenLabs.Tests
         }
 
         [Test]
-        public async Task Test_08_DeleteVoiceSample()
+        public async Task Test_10_DeleteVoiceSample()
         {
             Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
             var results = await ElevenLabsClient.VoicesEndpoint.GetAllVoicesAsync();
@@ -143,7 +179,7 @@ namespace ElevenLabs.Tests
         }
 
         [Test]
-        public async Task Test_09_DeleteVoice()
+        public async Task Test_11_DeleteVoice()
         {
             Assert.NotNull(ElevenLabsClient.VoicesEndpoint);
             var results = await ElevenLabsClient.VoicesEndpoint.GetAllVoicesAsync();

--- a/ElevenLabs-DotNet/Authentication/ElevenLabsAuthentication.cs
+++ b/ElevenLabs-DotNet/Authentication/ElevenLabsAuthentication.cs
@@ -51,9 +51,9 @@ namespace ElevenLabs
                     return cachedDefault;
                 }
 
-                var auth = (LoadFromDirectory()) ??
-                            LoadFromDirectory(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)) ??
-                            LoadFromEnv();
+                var auth = LoadFromDirectory() ??
+                           LoadFromDirectory(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)) ??
+                           LoadFromEnv();
                 cachedDefault = auth;
                 return auth;
             }

--- a/ElevenLabs-DotNet/Authentication/ElevenLabsClientSettings.cs
+++ b/ElevenLabs-DotNet/Authentication/ElevenLabsClientSettings.cs
@@ -6,8 +6,9 @@ namespace ElevenLabs
 {
     public sealed class ElevenLabsClientSettings
     {
-        internal const string ElevenLabsDomain = "api.elevenlabs.io";
+        internal const string Https = "https://";
         internal const string DefaultApiVersion = "v1";
+        internal const string ElevenLabsDomain = "api.elevenlabs.io";
 
         /// <summary>
         /// Creates a new instance of <see cref="ElevenLabsClientSettings"/> for use with ElevenLabs API.
@@ -17,7 +18,7 @@ namespace ElevenLabs
             Domain = ElevenLabsDomain;
             ApiVersion = "v1";
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{Domain}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{Https}{Domain}{BaseRequest}{{0}}";
         }
 
         /// <summary>
@@ -32,8 +33,8 @@ namespace ElevenLabs
                 domain = ElevenLabsDomain;
             }
 
-            if (!domain.Contains(".") &&
-                !domain.Contains(":"))
+            if (!domain.Contains('.') &&
+                !domain.Contains(':'))
             {
                 throw new ArgumentException($"You're attempting to pass a \"resourceName\" parameter to \"{nameof(domain)}\". Please specify \"resourceName:\" for this parameter in constructor.");
             }
@@ -43,10 +44,10 @@ namespace ElevenLabs
                 apiVersion = DefaultApiVersion;
             }
 
-            Domain = domain;
+            Domain = domain.Contains("http") ? domain : $"{Https}{domain}";
             ApiVersion = apiVersion;
             BaseRequest = $"/{ApiVersion}/";
-            BaseRequestUrlFormat = $"https://{Domain}{BaseRequest}{{0}}";
+            BaseRequestUrlFormat = $"{Domain}{BaseRequest}{{0}}";
         }
 
         public string Domain { get; }
@@ -57,6 +58,6 @@ namespace ElevenLabs
 
         public string BaseRequestUrlFormat { get; }
 
-        public static ElevenLabsClientSettings Default { get; } = new ElevenLabsClientSettings();
+        public static ElevenLabsClientSettings Default { get; } = new();
     }
 }

--- a/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
+++ b/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
@@ -12,10 +12,14 @@
     <Authors>Stephen Hodgson</Authors>
     <Title>ElevenLabs-DotNet</Title>
     <Company>RageAgainstThePixel</Company>
-    <Copyright>2023</Copyright>
+    <Copyright>2024</Copyright>
     <PackageTags>ElevenLabs, AI, ML, Voice, TTS</PackageTags>
-    <Version>2.1.1</Version>
-    <PackageReleaseNotes>Version 2.1.1
+    <Version>2.2.0</Version>
+    <PackageReleaseNotes>Version 2.2.0
+- Changed ElevenLabsClient to be IDisposable
+  - The ElevenLabsClient must now be disposed if you do not pass your own HttpClient
+- Updated ElevenLabsClientSettings to accept custom domains
+Version 2.1.1
 - Added VoicesEndpoint.GetAllVoicesAsync overload that allows skipping downloading the voice settings
 Version 2.1.0
 - Added ElevenLabsClient.EnableDebug option to enable and disable for all endpoints

--- a/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
+++ b/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
@@ -19,6 +19,7 @@
 - Changed ElevenLabsClient to be IDisposable
   - The ElevenLabsClient must now be disposed if you do not pass your own HttpClient
 - Updated ElevenLabsClientSettings to accept custom domains
+- Added filesystemless overloads for uploading audio clips
 Version 2.1.1
 - Added VoicesEndpoint.GetAllVoicesAsync overload that allows skipping downloading the voice settings
 Version 2.1.0

--- a/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
+++ b/ElevenLabs-DotNet/Voices/VoicesEndpoint.cs
@@ -203,6 +203,100 @@ namespace ElevenLabs.Voices
             return await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+		/// <summary>
+		/// Add a new voice to your collection of voices in VoiceLab from a stream
+		/// </summary>
+		/// <param name="name">Name of the voice you want to add.</param>
+		/// <param name="sampleDatums">Collection of samples as an array of bytes to be used for the new voice</param>
+		/// <param name="labels">Optional, labels for the new voice.</param>
+		/// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+		public async Task<Voice> AddVoiceAsync(string name, IEnumerable<byte[]> sampleDatums, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+		{
+			var form = new MultipartFormDataContent();
+
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				throw new ArgumentNullException(nameof(name));
+			}
+
+			form.Add(new StringContent(name), "name");
+
+			if (sampleDatums != null)
+			{
+				int fileItr = 0;
+				foreach (byte[] datum in sampleDatums)
+				{
+					try
+					{
+						form.Add(new ByteArrayContent(datum), "files", $"file-{fileItr++}");
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine(e);
+					}
+				}
+			}
+
+			if (labels != null)
+			{
+				form.Add(new StringContent(JsonSerializer.Serialize(labels)), "labels");
+			}
+
+			var response = await client.Client.PostAsync(GetUrl("/add"), form, cancellationToken).ConfigureAwait(false);
+			var responseAsString = await response.ReadAsStringAsync(EnableDebug, cancellationToken).ConfigureAwait(false);
+			var voiceResponse = JsonSerializer.Deserialize<VoiceResponse>(responseAsString, ElevenLabsClient.JsonSerializationOptions);
+			return await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Add a new voice to your collection of voices in VoiceLab from a stream
+		/// </summary>
+		/// <param name="name">Name of the voice you want to add.</param>
+		/// <param name="sampleStreams">Collection of samples as a stream to be used for the new voice</param>
+		/// <param name="labels">Optional, labels for the new voice.</param>
+		/// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
+		public async Task<Voice> AddVoiceAsync(string name, IEnumerable<Stream> sampleStreams, IReadOnlyDictionary<string, string> labels = null, CancellationToken cancellationToken = default)
+        {
+            var form = new MultipartFormDataContent();
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            form.Add(new StringContent(name), "name");
+
+            if (sampleStreams != null)
+            {
+                int fileItr = 0;
+                foreach (Stream voiceStream in sampleStreams)
+                {
+                    try
+                    {
+                        using (MemoryStream ms = new MemoryStream())
+                        {
+                            await voiceStream.CopyToAsync(ms, cancellationToken);
+                            form.Add(new ByteArrayContent(ms.ToArray()),"files", $"file-{fileItr++}");
+                        }
+					}
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e);
+                    }
+                }
+            }
+
+            if (labels != null)
+            {
+                form.Add(new StringContent(JsonSerializer.Serialize(labels)), "labels");
+            }
+
+            var response = await client.Client.PostAsync(GetUrl("/add"), form, cancellationToken).ConfigureAwait(false);
+            var responseAsString = await response.ReadAsStringAsync(EnableDebug, cancellationToken).ConfigureAwait(false);
+            var voiceResponse = JsonSerializer.Deserialize<VoiceResponse>(responseAsString, ElevenLabsClient.JsonSerializationOptions);
+            return await GetVoiceAsync(voiceResponse.VoiceId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Edit a voice created by you.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ In this example, we demonstrate how to set up and use `ElevenLabsProxyStartup` i
     - Powershell install: `Install-Package ElevenLabs-DotNet-Proxy`
     - Manually editing .csproj: `<PackageReference Include="ElevenLabs-DotNet-Proxy" />`
 3. Create a new class that inherits from `AbstractAuthenticationFilter` and override the `ValidateAuthentication` method. This will implement the `IAuthenticationFilter` that you will use to check user session token against your internal server.
-4. In `Program.cs`, create a new proxy web application by calling `ElevenLabsProxyStartup.CreateDefaultHost` method, passing your custom `AuthenticationFilter` as a type argument.
+4. In `Program.cs`, create a new proxy web application by calling `ElevenLabsProxyStartup.CreateWebApplication` method, passing your custom `AuthenticationFilter` as a type argument.
 5. Create `ElevenLabsAuthentication` and `ElevenLabsClientSettings` as you would normally with your API keys, org id, or Azure settings.
 
 ```csharp
@@ -156,7 +156,19 @@ public partial class Program
         {
             // You will need to implement your own class to properly test
             // custom issued tokens you've setup for your end users.
-            if (!request["xi-api-key"].ToString().Contains(userToken))
+            if (!request["xi-api-key"].ToString().Contains(TestUserToken))
+            {
+                throw new AuthenticationException("User is not authorized");
+            }
+        }
+
+        public override async Task ValidateAuthenticationAsync(IHeaderDictionary request)
+        {
+            await Task.CompletedTask; // remote resource call
+
+            // You will need to implement your own class to properly test
+            // custom issued tokens you've setup for your end users.
+            if (!request["xi-api-key"].ToString().Contains(TestUserToken))
             {
                 throw new AuthenticationException("User is not authorized");
             }
@@ -165,9 +177,9 @@ public partial class Program
 
     public static void Main(string[] args)
     {
-        var client = new ElevenLabsClient();
-        var proxy = ElevenLabsProxyStartup.CreateDefaultHost<AuthenticationFilter>(args, client);
-        proxy.Run();
+        var auth = ElevenLabsAuthentication.LoadFromEnv();
+        var client = new ElevenLabsClient(auth);
+        ElevenLabsProxyStartup.CreateWebApplication<AuthenticationFilter>(args, client).Run();
     }
 }
 ```


### PR DESCRIPTION
- Changed ElevenLabsClient to be IDisposable
  - The ElevenLabsClient must now be disposed if you do not pass your own HttpClient
- Updated ElevenLabsClientSettings to accept custom domains
- Added filesystemless overloads for uploading audio clips

ElevenLabs-DotNet-Proxy 2.2.0
- Updated implementation to include WebApplication builder