### PR TITLE
ElevenLabs-DotNet 3.4.0

### DIFF
--- a/ElevenLabs-DotNet-Tests/ElevenLabs-DotNet-Tests.csproj
+++ b/ElevenLabs-DotNet-Tests/ElevenLabs-DotNet-Tests.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <ProjectReference Include="..\ElevenLabs-DotNet\ElevenLabs-DotNet.csproj" />
         <ProjectReference Include="..\ElevenLabs-DotNet-Tests-Proxy\ElevenLabs-DotNet-Tests-Proxy.csproj" />
     </ItemGroup>

--- a/ElevenLabs-DotNet-Tests/TestFixture_04_TextToSpeechEndpoint.cs
+++ b/ElevenLabs-DotNet-Tests/TestFixture_04_TextToSpeechEndpoint.cs
@@ -43,5 +43,25 @@ namespace ElevenLabs.Tests
             Assert.NotNull(voiceClip);
             Console.WriteLine(voiceClip.Id);
         }
+
+        [Test]
+        public async Task Test_TurboV2_5_LanguageEnforced_TextToSpeech()
+        {
+            Assert.NotNull(ElevenLabsClient.TextToSpeechEndpoint);
+            var voice = Voices.Voice.Adam;
+            Assert.NotNull(voice);
+            var defaultVoiceSettings = await ElevenLabsClient.VoicesEndpoint.GetDefaultVoiceSettingsAsync();
+            var voiceClip = await ElevenLabsClient.TextToSpeechEndpoint.TextToSpeechAsync(
+                "Příliš žluťoučký kůň úpěl ďábelské ódy",
+                voice, 
+                defaultVoiceSettings,
+                Models.Model.TurboV2_5,
+                OutputFormat.MP3_44100_192,
+                null,
+                "cs");
+
+            Assert.NotNull(voiceClip);
+            Console.WriteLine(voiceClip.Id);
+        }
     }
 }

--- a/ElevenLabs-DotNet/Common/GeneratedClip.cs
+++ b/ElevenLabs-DotNet/Common/GeneratedClip.cs
@@ -7,12 +7,13 @@ namespace ElevenLabs
 {
     public class GeneratedClip
     {
-        internal GeneratedClip(string id, string text, ReadOnlyMemory<byte> clipData)
+        internal GeneratedClip(string id, string text, ReadOnlyMemory<byte> clipData, int sampleRate = 44100)
         {
             Id = id;
             Text = text;
             TextHash = $"{id}{text}".GenerateGuid().ToString();
             ClipData = clipData;
+            SampleRate = sampleRate;
         }
 
         /// <summary>
@@ -34,5 +35,7 @@ namespace ElevenLabs
         /// The ray clip data.
         /// </summary>
         public ReadOnlyMemory<byte> ClipData { get; }
+
+        public int SampleRate { get; }
     }
 }

--- a/ElevenLabs-DotNet/Common/TimestampedTranscriptCharacter.cs
+++ b/ElevenLabs-DotNet/Common/TimestampedTranscriptCharacter.cs
@@ -1,0 +1,42 @@
+﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace ElevenLabs
+{
+    /// <summary>
+    /// Represents timing information for a single character in the transcript
+    /// </summary>
+    public class TimestampedTranscriptCharacter
+    {
+        public TimestampedTranscriptCharacter() { }
+
+        internal TimestampedTranscriptCharacter(string character, double startTime, double endTime)
+        {
+            Character = character;
+            StartTime = startTime;
+            EndTime = endTime;
+        }
+
+        /// <summary>
+        /// The character being spoken
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("character")]
+        public string Character { get; private set; }
+
+        /// <summary>
+        /// The time in seconds when this character starts being spoken
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("character_start_times_seconds")]
+        public double StartTime { get; private set; }
+
+        /// <summary>
+        /// The time in seconds when this character finishes being spoken
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("character_end_times_seconds")]
+        public double EndTime { get; private set; }
+    }
+}

--- a/ElevenLabs-DotNet/Common/VoiceClip.cs
+++ b/ElevenLabs-DotNet/Common/VoiceClip.cs
@@ -7,11 +7,14 @@ namespace ElevenLabs
 {
     public sealed class VoiceClip : GeneratedClip
     {
-        internal VoiceClip(string id, string text, Voice voice, ReadOnlyMemory<byte> clipData) : base(id, text, clipData)
+        internal VoiceClip(string id, string text, Voice voice, ReadOnlyMemory<byte> clipData, int sampleRate = 44100)
+            : base(id, text, clipData, sampleRate)
         {
             Voice = voice;
         }
 
         public Voice Voice { get; }
+
+        public TimestampedTranscriptCharacter[] TimestampedTranscriptCharacters { get; internal init; }
     }
 }

--- a/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
+++ b/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
@@ -25,8 +25,13 @@ All copyrights, trademarks, logos, and assets are the property of their respecti
     <SignAssembly>false</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>3.1.0</Version>
+    <Version>3.4.0</Version>
     <PackageReleaseNotes>
+Version 3.4.0
+- Added additional request properties for TextToSpeechRequest
+  - previous_text, next_text, previous_request_ids, next_request_ids, languageCode, withTimestamps
+- Added support for transcription timestamps in TextToSpeechResponse
+- Added support for language code in TextToSpeechRequest
 Version 3.1.0
 - Refactored TextToSpeechEndpoint endpoint to accept TextToSpeechRequest object
   - Added text encoding options to TextToSpeechRequest

--- a/ElevenLabs-DotNet/Extensions/Extensions.cs
+++ b/ElevenLabs-DotNet/Extensions/Extensions.cs
@@ -1,0 +1,16 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace ElevenLabs.Extensions
+{
+    public static class Extensions
+    {
+        public static int GetSampleRate(this OutputFormat format) => format switch
+        {
+            OutputFormat.PCM_16000 => 16000,
+            OutputFormat.PCM_22050 => 22050,
+            OutputFormat.PCM_24000 => 24000,
+            OutputFormat.PCM_44100 => 44100,
+            _ => 44100
+        };
+    }
+}

--- a/ElevenLabs-DotNet/TextToSpeech/Alignment.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/Alignment.cs
@@ -1,0 +1,37 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace ElevenLabs.TextToSpeech
+{
+    internal sealed class Alignment
+    {
+        [JsonInclude]
+        [JsonPropertyName("characters")]
+        public string[] Characters { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("character_start_times_seconds")]
+        public double[] StartTimes { get; private set; }
+
+        [JsonInclude]
+        [JsonPropertyName("character_end_times_seconds")]
+        public double[] EndTimes { get; private set; }
+
+        public static implicit operator TimestampedTranscriptCharacter[](Alignment alignment)
+        {
+            if (alignment == null) { return null; }
+            var characters = alignment.Characters;
+            var startTimes = alignment.StartTimes;
+            var endTimes = alignment.EndTimes;
+            var timestampedTranscriptCharacters = new TimestampedTranscriptCharacter[characters.Length];
+
+            for (var i = 0; i < characters.Length; i++)
+            {
+                timestampedTranscriptCharacters[i] = new TimestampedTranscriptCharacter(characters[i], startTimes[i], endTimes[i]);
+            }
+
+            return timestampedTranscriptCharacters;
+        }
+    }
+}

--- a/ElevenLabs-DotNet/TextToSpeech/TextToSpeechEndpoint.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TextToSpeechEndpoint.cs
@@ -43,6 +43,10 @@ namespace ElevenLabs.TextToSpeech
         /// <param name="model">
         /// Optional, <see cref="Model"/> to use. Defaults to <see cref="Model.MonoLingualV1"/>.
         /// </param>
+        /// <param name="languageCode">
+        /// Optional, Language code (ISO 639-1) used to enforce a language for the model. Currently only <see cref="Model.TurboV2_5"/> supports language enforcement. 
+        /// For other models, an error will be returned if language code is provided.
+        /// </param>
         /// <param name="outputFormat">
         /// Output format of the generated audio.<br/>
         /// Defaults to <see cref="OutputFormat.MP3_44100_128"/>
@@ -64,10 +68,10 @@ namespace ElevenLabs.TextToSpeech
         /// </param>
         /// <param name="cancellationToken">Optional, <see cref="CancellationToken"/>.</param>
         /// <returns><see cref="VoiceClip"/>.</returns>
-        public async Task<VoiceClip> TextToSpeechAsync(string text, Voice voice, VoiceSettings voiceSettings = null, Model model = null, OutputFormat outputFormat = OutputFormat.MP3_44100_128, int? optimizeStreamingLatency = null, Func<VoiceClip, Task> partialClipCallback = null, CancellationToken cancellationToken = default)
+        public async Task<VoiceClip> TextToSpeechAsync(string text, Voice voice, VoiceSettings voiceSettings = null, Model model = null, OutputFormat outputFormat = OutputFormat.MP3_44100_128, int? optimizeStreamingLatency = null, string languageCode =  null, Func<VoiceClip, Task> partialClipCallback = null, CancellationToken cancellationToken = default)
         {
             var defaultVoiceSettings = voiceSettings ?? voice.Settings ?? await client.VoicesEndpoint.GetDefaultVoiceSettingsAsync(cancellationToken);
-            return await TextToSpeechAsync(new TextToSpeechRequest(voice, text, Encoding.UTF8, defaultVoiceSettings, outputFormat, optimizeStreamingLatency, model), partialClipCallback, cancellationToken).ConfigureAwait(false);
+            return await TextToSpeechAsync(new TextToSpeechRequest(voice, text, Encoding.UTF8, defaultVoiceSettings, outputFormat, optimizeStreamingLatency, model, languageCode), partialClipCallback, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
@@ -10,8 +10,9 @@ namespace ElevenLabs.TextToSpeech
 {
     public sealed class TextToSpeechRequest
     {
-        public TextToSpeechRequest(string text, Model model, VoiceSettings voiceSettings) :
-            this(null, text, voiceSettings: voiceSettings, model: model)
+        [Obsolete]
+        public TextToSpeechRequest(string text, Model model, VoiceSettings voiceSettings)
+            : this(null, text, voiceSettings: voiceSettings, model: model)
         {
         }
 
@@ -29,11 +30,7 @@ namespace ElevenLabs.TextToSpeech
         /// Optional, <see cref="VoiceSettings"/> that will override the default settings in <see cref="Voice.Settings"/>.
         /// </param>
         /// <param name="model">
-        /// Optional, <see cref="Model"/> to use. Defaults to <see cref="Model.MonoLingualV1"/>.
-        /// </param>
-        /// <param name="languageCode">
-        /// Optional, Language code (ISO 639-1) used to enforce a language for the model. Currently only <see cref="Model.TurboV2_5"/> supports language enforcement. 
-        /// For other models, an error will be returned if language code is provided.
+        /// Optional, <see cref="Model"/> to use. Defaults to <see cref="Model.TurboV2_5"/>.
         /// </param>
         /// <param name="outputFormat">
         /// Output format of the generated audio.<br/>
@@ -51,8 +48,14 @@ namespace ElevenLabs.TextToSpeech
         /// (best latency, but can mispronounce e.g. numbers and dates).
         /// </param>
         /// <param name="previousText"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        /// <param name="nextText"></param>
+        /// <param name="previousRequestIds"></param>
+        /// <param name="nextRequestIds"></param>
+        /// <param name="languageCode">
+        /// Optional, Language code (ISO 639-1) used to enforce a language for the model. Currently only <see cref="Model.TurboV2_5"/> supports language enforcement. 
+        /// For other models, an error will be returned if language code is provided.
+        /// </param>
+        /// <param name="withTimestamps"></param>
         public TextToSpeechRequest(
             Voice voice,
             string text,
@@ -61,8 +64,12 @@ namespace ElevenLabs.TextToSpeech
             OutputFormat outputFormat = OutputFormat.MP3_44100_128,
             int? optimizeStreamingLatency = null,
             Model model = null,
+            string previousText = null,
+            string nextText = null,
+            string[] previousRequestIds = null,
+            string[] nextRequestIds = null,
             string languageCode = null,
-            string previousText = null)
+            bool withTimestamps = false)
         {
             if (string.IsNullOrWhiteSpace(text))
             {
@@ -85,19 +92,26 @@ namespace ElevenLabs.TextToSpeech
                 text = Encoding.UTF8.GetString(encoding.GetBytes(text));
             }
 
-            if (!string.IsNullOrEmpty(languageCode) && model != Models.Model.TurboV2_5)
-            {
-                throw new ArgumentException($"Currently only Turbo v2.5 model supports language enforcement.", nameof(languageCode));
-            }
-
             Text = text;
-            Model = model ?? Models.Model.MultiLingualV2;
+            Model = model ?? Models.Model.TurboV2_5;
             Voice = voice;
-            VoiceSettings = voiceSettings ?? voice.Settings ?? throw new ArgumentNullException(nameof(voiceSettings));
-            PreviousText = previousText;
+            VoiceSettings = voiceSettings ?? voice.Settings;
             OutputFormat = outputFormat;
             OptimizeStreamingLatency = optimizeStreamingLatency;
+            PreviousText = previousText;
+            NextText = nextText;
+            if (previousRequestIds?.Length > 3)
+            {
+                previousRequestIds = previousRequestIds[..3];
+            }
+            PreviousRequestIds = previousRequestIds;
+            if (nextRequestIds?.Length > 3)
+            {
+                nextRequestIds = nextRequestIds[..3];
+            }
+            NextRequestIds = nextRequestIds;
             LanguageCode = languageCode;
+            WithTimestamps = withTimestamps;
         }
 
         [JsonPropertyName("text")]
@@ -106,14 +120,11 @@ namespace ElevenLabs.TextToSpeech
         [JsonPropertyName("model_id")]
         public string Model { get; }
 
-        [JsonPropertyName("language_code")]
-        public string LanguageCode { get; }
-
         [JsonIgnore]
         public Voice Voice { get; }
 
         [JsonPropertyName("voice_settings")]
-        public VoiceSettings VoiceSettings { get; }
+        public VoiceSettings VoiceSettings { get; internal set; }
 
         [JsonPropertyName("previous_text")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -124,5 +135,27 @@ namespace ElevenLabs.TextToSpeech
 
         [JsonIgnore]
         public int? OptimizeStreamingLatency { get; }
+
+        [JsonPropertyName("next_text")]
+        public string NextText { get; }
+
+        /// <remarks>
+        /// A maximum of three next or previous history item ids can be sent
+        /// </remarks>
+        [JsonPropertyName("previous_request_ids")]
+        public string[] PreviousRequestIds { get; }
+
+        /// <remarks>
+        /// A maximum of three next or previous history item ids can be sent
+        /// </remarks>
+        [JsonPropertyName("next_request_ids")]
+        public string[] NextRequestIds { get; }
+
+
+        [JsonPropertyName("language_code")]
+        public string LanguageCode { get; }
+
+        [JsonIgnore]
+        public bool WithTimestamps { get; }
     }
 }

--- a/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
@@ -31,6 +31,10 @@ namespace ElevenLabs.TextToSpeech
         /// <param name="model">
         /// Optional, <see cref="Model"/> to use. Defaults to <see cref="Model.MonoLingualV1"/>.
         /// </param>
+        /// <param name="languageCode">
+        /// Optional, Language code (ISO 639-1) used to enforce a language for the model. Currently only <see cref="Model.TurboV2_5"/> supports language enforcement. 
+        /// For other models, an error will be returned if language code is provided.
+        /// </param>
         /// <param name="outputFormat">
         /// Output format of the generated audio.<br/>
         /// Defaults to <see cref="OutputFormat.MP3_44100_128"/>
@@ -57,6 +61,7 @@ namespace ElevenLabs.TextToSpeech
             OutputFormat outputFormat = OutputFormat.MP3_44100_128,
             int? optimizeStreamingLatency = null,
             Model model = null,
+            string languageCode = null,
             string previousText = null)
         {
             if (string.IsNullOrWhiteSpace(text))
@@ -80,6 +85,11 @@ namespace ElevenLabs.TextToSpeech
                 text = Encoding.UTF8.GetString(encoding.GetBytes(text));
             }
 
+            if (!string.IsNullOrEmpty(languageCode) && model != Models.Model.TurboV2_5)
+            {
+                throw new ArgumentException($"Currently only Turbo v2.5 model supports language enforcement.", nameof(languageCode));
+            }
+
             Text = text;
             Model = model ?? Models.Model.MultiLingualV2;
             Voice = voice;
@@ -87,6 +97,7 @@ namespace ElevenLabs.TextToSpeech
             PreviousText = previousText;
             OutputFormat = outputFormat;
             OptimizeStreamingLatency = optimizeStreamingLatency;
+            LanguageCode = languageCode;
         }
 
         [JsonPropertyName("text")]
@@ -94,6 +105,9 @@ namespace ElevenLabs.TextToSpeech
 
         [JsonPropertyName("model_id")]
         public string Model { get; }
+
+        [JsonPropertyName("language_code")]
+        public string LanguageCode { get; }
 
         [JsonIgnore]
         public Voice Voice { get; }

--- a/ElevenLabs-DotNet/TextToSpeech/TranscriptionResponse.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TranscriptionResponse.cs
@@ -1,0 +1,21 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace ElevenLabs.TextToSpeech
+{
+    internal sealed class TranscriptionResponse
+    {
+        [JsonInclude]
+        [JsonPropertyName("audio_base64")]
+        public string AudioBase64 { get; private set; }
+
+        [JsonIgnore]
+        public byte[] AudioBytes => Convert.FromBase64String(AudioBase64);
+
+        [JsonInclude]
+        [JsonPropertyName("alignment")]
+        public Alignment Alignment { get; private set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ dotnet add package ElevenLabs-DotNet
 - [Text to Speech](#text-to-speech)
   - [Stream Text To Speech](#stream-text-to-speech)
 - [Voices](#voices)
-  - [Get Shared Voices](#get-shared-voices) :new:
+  - [Get Shared Voices](#get-shared-voices)
   - [Get All Voices](#get-all-voices)
   - [Get Default Voice Settings](#get-default-voice-settings)
   - [Get Voice](#get-voice)
@@ -58,13 +58,13 @@ dotnet add package ElevenLabs-DotNet
   - [Samples](#samples)
     - [Download Voice Sample](#download-voice-sample)
     - [Delete Voice Sample](#delete-voice-sample)
-- [Dubbing](#dubbing) :new:
-  - [Dub](#dub) :new:
-  - [Get Dubbing Metadata](#get-dubbing-metadata) :new:
-  - [Get Transcript for Dub](#get-transcript-for-dub) :new:
-  - [Get dubbed file](#get-dubbed-file) :new:
-  - [Delete Dubbing Project](#delete-dubbing-project) :new:
-- [SFX Generation](#sfx-generation) :new:
+- [Dubbing](#dubbing)
+  - [Dub](#dub)
+  - [Get Dubbing Metadata](#get-dubbing-metadata)
+  - [Get Transcript for Dub](#get-transcript-for-dub)
+  - [Get dubbed file](#get-dubbed-file)
+  - [Delete Dubbing Project](#delete-dubbing-project)
+- [SFX Generation](#sfx-generation)
 - [History](#history)
   - [Get History](#get-history)
   - [Get History Item](#get-history-item)

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ Convert text to speech.
 var api = new ElevenLabsClient();
 var text = "The quick brown fox jumps over the lazy dog.";
 var voice = (await api.VoicesEndpoint.GetAllVoicesAsync()).FirstOrDefault();
-var defaultVoiceSettings = await api.VoicesEndpoint.GetDefaultVoiceSettingsAsync();
-var voiceClip = await api.TextToSpeechEndpoint.TextToSpeechAsync(text, voice, defaultVoiceSettings);
+var request = new TextToSpeechRequest(voice, text);
+var voiceClip = await api.TextToSpeechEndpoint.TextToSpeechAsync(request);
 await File.WriteAllBytesAsync($"{voiceClip.Id}.mp3", voiceClip.ClipData.ToArray());
 ```
 
@@ -219,7 +219,8 @@ var text = "The quick brown fox jumps over the lazy dog.";
 var voice = (await api.VoicesEndpoint.GetAllVoicesAsync()).FirstOrDefault();
 string fileName = "myfile.mp3";
 using var outputFileStream = File.OpenWrite(fileName);
-var voiceClip = await api.TextToSpeechEndpoint.TextToSpeechAsync(text, voice,
+var request = new TextToSpeechRequest(voice, text);
+var voiceClip = await api.TextToSpeechEndpoint.TextToSpeechAsync(request,
 partialClipCallback: async (partialClip) =>
 {
     // Write the incoming data to the output file stream.


### PR DESCRIPTION
- Added additional request properties for TextToSpeechRequest
  - `previous_text`, `next_text`, `previous_request_ids`, `next_request_ids`, `languageCode`, `withTimestamps`
- Added support for transcription timestamps by @tomkail
- Added support for language code in TextToSpeechRequest @Mylan719