### PR TITLE
ElevenLabs-DotNet 3.4.1

### DIFF
--- a/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
+++ b/ElevenLabs-DotNet/ElevenLabs-DotNet.csproj
@@ -25,8 +25,10 @@ All copyrights, trademarks, logos, and assets are the property of their respecti
     <SignAssembly>false</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <PackageReleaseNotes>
+Version 3.4.1
+- Removed text length check in TextToSpeechRequest
 Version 3.4.0
 - Added additional request properties for TextToSpeechRequest
   - previous_text, next_text, previous_request_ids, next_request_ids, languageCode, withTimestamps

--- a/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
+++ b/ElevenLabs-DotNet/TextToSpeech/TextToSpeechRequest.cs
@@ -23,7 +23,7 @@ namespace ElevenLabs.TextToSpeech
         /// <see cref="Voice"/> to use.
         /// </param>
         /// <param name="text">
-        /// Text input to synthesize speech for. Maximum 5000 characters.
+        /// Text input to synthesize speech for.
         /// </param>
         /// <param name="encoding"><see cref="Encoding"/> to use for <see cref="text"/>.</param>
         /// <param name="voiceSettings">
@@ -74,11 +74,6 @@ namespace ElevenLabs.TextToSpeech
             if (string.IsNullOrWhiteSpace(text))
             {
                 throw new ArgumentNullException(nameof(text));
-            }
-
-            if (text.Length > 5000)
-            {
-                throw new ArgumentOutOfRangeException(nameof(text), $"{nameof(text)} cannot exceed 5000 characters");
             }
 
             if (voice == null ||


### PR DESCRIPTION
- Removed text length check in TextToSpeechRequest