### PR TITLE
ElevenLabs-DotNet-Proxy 3.5.2

### DIFF
--- a/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
+++ b/ElevenLabs-DotNet-Proxy/ElevenLabs-DotNet-Proxy.csproj
@@ -20,8 +20,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <SignAssembly>false</SignAssembly>
-    <Version>3.5.1</Version>
+    <Version>3.5.2</Version>
     <PackageReleaseNotes>
+Version 3.5.2
+- Forward the content and headers from the backend service to the client, preserving the original response details.
 Version 3.5.1
 - Bug fixes and better logging support.
 Version 3.0.0

--- a/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
@@ -108,6 +108,8 @@ namespace ElevenLabs.Proxy
                     }
                     else
                     {
+                        httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString() ?? "application/json";
+                        httpContext.Response.ContentLength = proxyResponse.Content.Headers.ContentLength;
                         await proxyResponse.Content.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted).ConfigureAwait(false);
                     }
                 }

--- a/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
@@ -85,6 +85,8 @@ namespace ElevenLabs.Proxy
 
                     var proxyResponse = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, httpContext.RequestAborted).ConfigureAwait(false);
                     httpContext.Response.StatusCode = (int)proxyResponse.StatusCode;
+                    httpContext.Response.ContentLength = proxyResponse.Content.Headers.ContentLength;
+                    httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString() ?? string.Empty;
 
                     foreach (var (key, value) in proxyResponse.Headers)
                     {
@@ -98,7 +100,6 @@ namespace ElevenLabs.Proxy
                         httpContext.Response.Headers[key] = value.ToArray();
                     }
 
-                    httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString() ?? string.Empty;
                     const string streamingContent = "text/event-stream";
 
                     if (httpContext.Response.ContentType.Equals(streamingContent))
@@ -108,7 +109,6 @@ namespace ElevenLabs.Proxy
                     }
                     else
                     {
-                        httpContext.Response.ContentLength = proxyResponse.Content.Headers.ContentLength;
                         await proxyResponse.Content.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted).ConfigureAwait(false);
                     }
                 }

--- a/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
@@ -108,7 +108,6 @@ namespace ElevenLabs.Proxy
                     }
                     else
                     {
-                        httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString() ?? "application/json";
                         httpContext.Response.ContentLength = proxyResponse.Content.Headers.ContentLength;
                         await proxyResponse.Content.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted).ConfigureAwait(false);
                     }

--- a/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
+++ b/ElevenLabs-DotNet-Proxy/Proxy/EndpointRouteBuilder.cs
@@ -86,7 +86,7 @@ namespace ElevenLabs.Proxy
                     var proxyResponse = await client.Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, httpContext.RequestAborted).ConfigureAwait(false);
                     httpContext.Response.StatusCode = (int)proxyResponse.StatusCode;
                     httpContext.Response.ContentLength = proxyResponse.Content.Headers.ContentLength;
-                    httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString() ?? string.Empty;
+                    httpContext.Response.ContentType = proxyResponse.Content.Headers.ContentType?.ToString();
 
                     foreach (var (key, value) in proxyResponse.Headers)
                     {
@@ -102,7 +102,8 @@ namespace ElevenLabs.Proxy
 
                     const string streamingContent = "text/event-stream";
 
-                    if (httpContext.Response.ContentType.Equals(streamingContent))
+                    if (httpContext.Response.ContentType != null &&
+                        httpContext.Response.ContentType.Equals(streamingContent, StringComparison.OrdinalIgnoreCase))
                     {
                         var stream = await proxyResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
                         await WriteServerStreamEventsAsync(httpContext, stream).ConfigureAwait(false);


### PR DESCRIPTION
- Forward the content and headers from the backend service to the client, preserving the original response details.