### PR TITLE
fix: Add Enum extension for EnumMemberAttribute serialization

### DIFF
--- a/ElevenLabs-DotNet/Dubbing/DubbingEndpoint.cs
+++ b/ElevenLabs-DotNet/Dubbing/DubbingEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using ElevenLabs.Extensions;
+using ElevenLabs.Utils;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -177,7 +178,7 @@ namespace ElevenLabs.Dubbing
         /// </returns>
         public async Task<string> GetTranscriptForDubAsync(string dubbingId, string languageCode, DubbingFormat formatType = DubbingFormat.Srt, CancellationToken cancellationToken = default)
         {
-            var @params = new Dictionary<string, string> { { "format_type", formatType.ToString().ToLower() } };
+            var @params = new Dictionary<string, string> { { "format_type", formatType.ToEnumString() } };
             using var response = await client.Client.GetAsync(GetUrl($"/{dubbingId}/transcript/{languageCode}", @params), cancellationToken).ConfigureAwait(false);
             return await response.ReadAsStringAsync(EnableDebug, cancellationToken).ConfigureAwait(false);
         }

--- a/ElevenLabs-DotNet/Utils/EnumExtensions.cs
+++ b/ElevenLabs-DotNet/Utils/EnumExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace ElevenLabs.Utils
+{
+    public static class EnumExtensions
+    {
+        /// <summary>
+        /// Serialize an enum according to the EnumMemberAttribute annotation, if available.
+        /// 
+        /// see https://stackoverflow.com/a/10418943
+        /// </summary>
+        /// <typeparam name="T">The enum type</typeparam>
+        /// <param name="enumValue">The enum value to serialize</param>
+        /// <returns></returns>
+        public static string ToEnumString<T>(this T enumValue) where T : Enum
+        {
+            var enumType = typeof(T);
+            var name = Enum.GetName(enumType, enumValue);
+            var enumMemberAttribute = ((EnumMemberAttribute[])enumType.GetField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true)).SingleOrDefault();
+            return enumMemberAttribute?.Value ?? enumValue.ToString();
+        }
+    }
+}

--- a/ElevenLabs-DotNet/Voices/VoiceQuery.cs
+++ b/ElevenLabs-DotNet/Voices/VoiceQuery.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using ElevenLabs.Utils;
 
 namespace ElevenLabs.Voices
 {
@@ -127,22 +128,22 @@ namespace ElevenLabs.Voices
 
             if (SortDirection.HasValue)
             {
-                parameters.Add("sort_direction", SortDirection.Value.ToString());
+                parameters.Add("sort_direction", SortDirection.Value.ToEnumString());
             }
 
             if (VoiceType.HasValue)
             {
-                parameters.Add("voice_type", VoiceType.Value.ToString());
+                parameters.Add("voice_type", VoiceType.Value.ToEnumString());
             }
 
             if (Category.HasValue)
             {
-                parameters.Add("category", Category.Value.ToString());
+                parameters.Add("category", Category.Value.ToEnumString());
             }
 
             if (FineTuningState.HasValue)
             {
-                parameters.Add("fine_tuning_state", FineTuningState.Value.ToString());
+                parameters.Add("fine_tuning_state", FineTuningState.Value.ToEnumString());
             }
 
             if (!string.IsNullOrWhiteSpace(CollectionId))


### PR DESCRIPTION
This is a fix for the [EnumMember(...)] serialization, which is not considered in ToString() but only by DataContract serializers.

I added an extension method to check for the attribute and use it for serialization.

For DubbingFormat it did not work either, that's why a ToLower was required to get the desired string.
